### PR TITLE
http_file_download: Add call to done in fragment timeout

### DIFF
--- a/app/common/src/http_file_download.c
+++ b/app/common/src/http_file_download.c
@@ -284,5 +284,6 @@ static void fragment_wdog_handler(struct k_work *work)
 	if (p->busy) {
 		r = download_client_disconnect(&p->dlc);
 		LOG_ERR("Disconnecting due to rx fragment timeout: %d", r);
+		hfd_done(-ETIMEDOUT);
 	}
 }


### PR DESCRIPTION
Force done when fragment timeout occurs.

Signed-off-by: Andrew Hedin <andrew.hedin@lairdconnect.com>
